### PR TITLE
Add --rawinput (-ri) argument support

### DIFF
--- a/SharpCalculator/ConsoleApplication.cs
+++ b/SharpCalculator/ConsoleApplication.cs
@@ -135,6 +135,17 @@ namespace SharpCalculatorApp
                             }
 
                             break;
+
+                        case "-ri":
+                        case "--rawinput":
+                            string[] expressions = LoadFile(args[i + 1]);
+                            foreach (string expression in expressions)
+                            {
+                                Console.WriteLine($"{expression} = {calc.ProcessExpression(expression)}");
+                                lineNumber++;
+                            }
+
+                            break;
                     }
                     i++;
                 }


### PR DESCRIPTION
Add the ability to use the argument `--rawinput` (alias `-ri`) instead of `--input` / `-i`.  
This allows to process the operations contained a file without `Processing ... :` and the line number being printed in `stdout`.